### PR TITLE
Remove SSC overview link from Gemfire PCF subnav

### DIFF
--- a/master_middleman/source/subnavs/gemfire_pcf_subnav.erb
+++ b/master_middleman/source/subnavs/gemfire_pcf_subnav.erb
@@ -21,18 +21,6 @@
       </li>
 
       <li class="has_submenu">
-        <a href="/ssc-gemfire/overview.html">Overview</a>
-        <ul>
-          <li>
-            <a href="/ssc-gemfire/overview.html#gemfire_config_details">GemFire Cache Configuration</a>
-          </li>
-          <li>
-            <a href="/ssc-gemfire/overview.html#how_it_works">How Does the Service Work?</a>
-          </li>
-        </ul>
-      </li>
-
-      <li class="has_submenu">
         <a href="/gemfire-cf/installing.html">Installing GemFire for Pivotal Cloud Foundry&reg;</a>
         <ul>
           <li>


### PR DESCRIPTION
The Gemfire PCF subnav had two overview links, one
pointing to the p-ssc-gemfire docs. The subnav should
not be linking to another product.
