### PR TITLE
Remove release notes links from the SSC subnav

### DIFF
--- a/master_middleman/source/subnavs/gemfire_cf_subnav.erb
+++ b/master_middleman/source/subnavs/gemfire_cf_subnav.erb
@@ -8,21 +8,8 @@
         <a id='home-nav-link' href="/ssc-gemfire/index.html">Session State Caching Powered by GemFire</a>
       </li>
 
-      <li class="has_submenu">
+      <li>
         <a href="/ssc-gemfire/relnotes.html">Release Notes</a>
-        <ul>
-          <li><a href="/ssc-gemfire/relnotes.html#v1150">v1.1.5.0</a></li>
-          <li><a href="/ssc-gemfire/relnotes.html#v1140">v1.1.4.0</a></li>
-          <li><a href="/ssc-gemfire/relnotes.html#v1130">v1.1.3.0</a></li>
-          <li><a href="/ssc-gemfire/relnotes.html#v1102">v1.1.0.2</a></li>
-          <li><a href="/ssc-gemfire/relnotes.html#v1120">v1.1.2.0</a></li>
-          <li><a href="/ssc-gemfire/relnotes.html#v1101">v1.1.0.1</a></li>
-          <li><a href="/ssc-gemfire/relnotes.html#v1110">v1.1.1.0</a></li>
-          <li><a href="/ssc-gemfire/relnotes.html#v1100">v1.1.0.0</a></li>
-          <li><a href="/ssc-gemfire/relnotes.html#v1020">v1.0.2.0</a></li>
-          <li><a href="/ssc-gemfire/relnotes.html#v1010">v1.0.1.0</a></li>
-          <li><a href="/ssc-gemfire/relnotes.html#v1000">v1.0.0.0</a></li>
-        </ul>
       </li>
 
       <li class="has_submenu">


### PR DESCRIPTION
Rather than updating this subnav everytime we cut a new version of
_Session-State Caching Powered by GemFire for PCF_, let's just link to
the release notes page.

Notably, this subnav is missing quite a few versions.
