### PR TITLE
use correct tag for ODB v0.6.0

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -119,6 +119,7 @@ sections:
   subnav_template: pivotal_new_relic_service_subnav.erb
 - repository:
     name: pivotal-cf/docs-on-demand-service-broker
+    ref: v0.6.0
   directory: on-demand-service-broker
   subnav_template: pivotal_on_demand_broker_subnav_v0-6-0.erb
 - repository:


### PR DESCRIPTION
ODB v0.6.0 needs to use the `v0.6.0` tag of its docs repo. As pointed out [here](https://github.com/pivotal-cf/docs-book-pcfservices/pull/17), this is not a branch, but it is a tag. We have used bookbinder successfully with tags before.

Please let us know if there's a problem.

(cc @avade @bentarnoff )
