### PR TITLE
release ODB 0.8.0

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -12,8 +12,8 @@ elastic_search: true
 products:
   - id: sso
     subnav_root: p-identity/index.html
-  - id: odb
-    subnav_root: on-demand-service-broker/index.html
+  - id: odb-v0-8-0
+    subnav_root: on-demand-service-broker/0.8.0/index.html
 
 sections:
 # cross-product resources
@@ -167,23 +167,71 @@ sections:
 - repository:
     name: pivotal-cf/docs-on-demand-service-broker
     ref: v0.8.0
-  directory: on-demand-service-broker
-  product_id: odb
+  directory: on-demand-service-broker/0.8.0
+  product_id: odb-v0-8-0
+  product_info:
+    use_local_header: true
+    latest_stable_version: 0.8.0
+    local_header_img: /on-demand-service-broker/0.8.0/img/pcf-services-sdk.png
+    local_header_title: On-Demand Service Broker SDK
+    search_placeholder: Search
+    local_product_version: 0.8.0
+    local_header_links: []
+    local_header_version_list:
+      - <a href="/on-demand-service-broker/0.7.0">v0.7.0</a>
+      - <a href="/on-demand-service-broker/0.6.0">v0.6.0</a>
+      - <a href="/on-demand-service-broker/0.5.0">v0.5.0</a>
 - repository:
     name: pivotal-cf/docs-on-demand-service-broker
     ref: v0.7.0
-  directory: on-demand-service-broker-v0-7-0
+  directory: on-demand-service-broker/0.7.0
   subnav_template: pivotal_on_demand_broker_subnav_v0-7-0.erb
+  product_info:
+    use_local_header: true
+    latest_stable_version: 0.8.0
+    local_header_img: /on-demand-service-broker/0.8.0/img/pcf-services-sdk.png
+    local_header_title: On-Demand Service Broker SDK
+    search_placeholder: Search
+    local_product_version: 0.7.0
+    local_header_links: []
+    local_header_version_list:
+      - <a href="/on-demand-service-broker/0.8.0">v0.8.0</a>
+      - <a href="/on-demand-service-broker/0.6.0">v0.6.0</a>
+      - <a href="/on-demand-service-broker/0.5.0">v0.5.0</a>
 - repository:
     name: pivotal-cf/docs-on-demand-service-broker
     ref: v0.6.0
-  directory: on-demand-service-broker-v0-6-0
+  directory: on-demand-service-broker/0.6.0
   subnav_template: pivotal_on_demand_broker_subnav_v0-6-0.erb
+  product_info:
+    use_local_header: true
+    latest_stable_version: 0.8.0
+    local_header_img: /on-demand-service-broker/0.8.0/img/pcf-services-sdk.png
+    local_header_title: On-Demand Service Broker SDK
+    search_placeholder: Search
+    local_product_version: 0.6.0
+    local_header_links: []
+    local_header_version_list:
+      - <a href="/on-demand-service-broker/0.8.0">v0.8.0</a>
+      - <a href="/on-demand-service-broker/0.7.0">v0.7.0</a>
+      - <a href="/on-demand-service-broker/0.5.0">v0.5.0</a>
 - repository:
     name: pivotal-cf/docs-on-demand-service-broker
     ref: v0.5.x
-  directory: on-demand-service-broker-v0-5-0
+  directory: on-demand-service-broker/0.5.0
   subnav_template: pivotal_on_demand_broker_subnav_v0-5-0.erb
+  product_info:
+    use_local_header: true
+    latest_stable_version: 0.8.0
+    local_header_img: /on-demand-service-broker/0.8.0/img/pcf-services-sdk.png
+    local_header_title: On-Demand Service Broker SDK
+    search_placeholder: Search
+    local_product_version: 0.5.0
+    local_header_links: []
+    local_header_version_list:
+      - <a href="/on-demand-service-broker/0.8.0">v0.8.0</a>
+      - <a href="/on-demand-service-broker/0.7.0">v0.7.0</a>
+      - <a href="/on-demand-service-broker/0.6.0">v0.6.0</a>
 - repository:
     name: pivotal-cf/docs-partners
   directory: partners

--- a/master_middleman/source/subnavs/pivotal_on_demand_broker_subnav_v0-5-0.erb
+++ b/master_middleman/source/subnavs/pivotal_on_demand_broker_subnav_v0-5-0.erb
@@ -5,189 +5,189 @@
   <div class="nav-content deepnav-content">
     <ul>
       <li>
-        <a id='home-nav-link' href="/on-demand-service-broker-v0-5-0/index.html">On-demand Service Broker for Pivotal Cloud Foundry</a>
+        <a id='home-nav-link' href="/on-demand-service-broker/0.5.0/index.html">On-demand Service Broker for Pivotal Cloud Foundry</a>
       </li>
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-5-0/overview.html">Overview</a>
+        <a href="/on-demand-service-broker/0.5.0/overview.html">Overview</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/overview.html#what-is-a-cloud-foundry-service-broker">What is a Cloud Foundry service broker?</a>
+            <a href="/on-demand-service-broker/0.5.0/overview.html#what-is-a-cloud-foundry-service-broker">What is a Cloud Foundry service broker?</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/overview.html#what-is-an-on-demand-service-broker">What is an on-demand service broker?</a>
+            <a href="/on-demand-service-broker/0.5.0/overview.html#what-is-an-on-demand-service-broker">What is an on-demand service broker?</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/overview.html#what-is-a-service-adapter">What is a service adapter</a>
+            <a href="/on-demand-service-broker/0.5.0/overview.html#what-is-a-service-adapter">What is a service adapter</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/overview.html#why-provision-iaas-resources-on-demand">Why provision IAAS resources on-demand?</a>
+            <a href="/on-demand-service-broker/0.5.0/overview.html#why-provision-iaas-resources-on-demand">Why provision IAAS resources on-demand?</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/overview.html#why-use-odb-to-develop-on-demand-service-offerings">Why use ODB to develop on-demand service offerings?</a>
+            <a href="/on-demand-service-broker/0.5.0/overview.html#why-use-odb-to-develop-on-demand-service-offerings">Why use ODB to develop on-demand service offerings?</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-5-0/overview.html#prerequisites-for-deploying-brokers-that-use-odb">Prerequisites for deploying brokers that use ODB</a>
+            <a href="/on-demand-service-broker/0.5.0/overview.html#prerequisites-for-deploying-brokers-that-use-odb">Prerequisites for deploying brokers that use ODB</a>
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/overview.html#bosh-v2-features-we-use">BOSH v2 Features we use</a>
+                <a href="/on-demand-service-broker/0.5.0/overview.html#bosh-v2-features-we-use">BOSH v2 Features we use</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/overview.html#steps-required-to-use-on-demand-service-broker">Steps required to use on-demand service broker</a>
+            <a href="/on-demand-service-broker/0.5.0/overview.html#steps-required-to-use-on-demand-service-broker">Steps required to use on-demand service broker</a>
           </li>
         </ul>
       </li>
 
       <li>
-        <a href="/on-demand-service-broker-v0-5-0/getting-started.html">Setting up a local environment</a>
+        <a href="/on-demand-service-broker/0.5.0/getting-started.html">Setting up a local environment</a>
       </li>
 
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-5-0/creating.html">Creating a service adapter</a>
+        <a href="/on-demand-service-broker/0.5.0/creating.html">Creating a service adapter</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/creating.html#what-is-required-of-the-service-authors">What is required of the Service Authors?</a>
+            <a href="/on-demand-service-broker/0.5.0/creating.html#what-is-required-of-the-service-authors">What is required of the Service Authors?</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/creating.html#creating-a-service-release">Creating a Service Release</a>
+            <a href="/on-demand-service-broker/0.5.0/creating.html#creating-a-service-release">Creating a Service Release</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-5-0/creating.html#creating-a-service-adapter">Creating a Service Adapter</a>
+            <a href="/on-demand-service-broker/0.5.0/creating.html#creating-a-service-adapter">Creating a Service Adapter</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/creating.html#handling-errors">Handling errors</a>
+                <a href="/on-demand-service-broker/0.5.0/creating.html#handling-errors">Handling errors</a>
               </li>
             </ul>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-5-0/creating.html#inputs-for-manifest-generation">Inputs for manifest generation</a>
+            <a href="/on-demand-service-broker/0.5.0/creating.html#inputs-for-manifest-generation">Inputs for manifest generation</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/creating.html#arbitrary-parameters">Arbitrary parameters</a>
+                <a href="/on-demand-service-broker/0.5.0/creating.html#arbitrary-parameters">Arbitrary parameters</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/creating.html#previous-manifest-properties">Previous manifest properties</a>
+                <a href="/on-demand-service-broker/0.5.0/creating.html#previous-manifest-properties">Previous manifest properties</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/creating.html#service-plan-properties">Service plan properties</a>
+                <a href="/on-demand-service-broker/0.5.0/creating.html#service-plan-properties">Service plan properties</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/creating.html#order-of-precedence">Order of precedence</a>
+                <a href="/on-demand-service-broker/0.5.0/creating.html#order-of-precedence">Order of precedence</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/creating.html#service-adapter-interface">Service adapter interface</a>
+            <a href="/on-demand-service-broker/0.5.0/creating.html#service-adapter-interface">Service adapter interface</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-5-0/creating.html#sub-commands">Subcommands</a>
+            <a href="/on-demand-service-broker/0.5.0/creating.html#sub-commands">Subcommands</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/creating.html#generate-manifest">generate-manifest</a>
+                <a href="/on-demand-service-broker/0.5.0/creating.html#generate-manifest">generate-manifest</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/creating.html#dashboard-url">dashboard-url</a>
+                <a href="/on-demand-service-broker/0.5.0/creating.html#dashboard-url">dashboard-url</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/creating.html#create-binding">create-binding</a>
+                <a href="/on-demand-service-broker/0.5.0/creating.html#create-binding">create-binding</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/creating.html#delete-binding">delete-binding</a>
+                <a href="/on-demand-service-broker/0.5.0/creating.html#delete-binding">delete-binding</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/creating.html#packaging">Packaging</a>
+            <a href="/on-demand-service-broker/0.5.0/creating.html#packaging">Packaging</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/creating.html#sdk">Golang SDK</a>
+            <a href="/on-demand-service-broker/0.5.0/creating.html#sdk">Golang SDK</a>
           </li>
         </ul>
       </li>
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-5-0/operating.html">Operating the On-demand Service Broker</a>
+        <a href="/on-demand-service-broker/0.5.0/operating.html">Operating the On-demand Service Broker</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/operating.html#what-are-the-responsibilities-of-the-operator">What are the responsibilities of the Operator?</a>
+            <a href="/on-demand-service-broker/0.5.0/operating.html#what-are-the-responsibilities-of-the-operator">What are the responsibilities of the Operator?</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-5-0/operating.html#configure-bosh">Setting up your BOSH director</a>
+            <a href="/on-demand-service-broker/0.5.0/operating.html#configure-bosh">Setting up your BOSH director</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/operating.html#ssl-certificates">SSL certificates</a>
+                <a href="/on-demand-service-broker/0.5.0/operating.html#ssl-certificates">SSL certificates</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/operating.html#bosh-teams">BOSH teams</a>
+                <a href="/on-demand-service-broker/0.5.0/operating.html#bosh-teams">BOSH teams</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/operating.html#upload-required-releases">Upload Required Releases</a>
+            <a href="/on-demand-service-broker/0.5.0/operating.html#upload-required-releases">Upload Required Releases</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-5-0/operating.html#write-a-broker-manifest">Write a Broker Manifest</a>
+            <a href="/on-demand-service-broker/0.5.0/operating.html#write-a-broker-manifest">Write a Broker Manifest</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/operating.html#core-broker-configuration">Core Broker Configuration</a>
+                <a href="/on-demand-service-broker/0.5.0/operating.html#core-broker-configuration">Core Broker Configuration</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/operating.html#service-catalog-and-plan-composition">Service catalog and Plan composition</a>
+                <a href="/on-demand-service-broker/0.5.0/operating.html#service-catalog-and-plan-composition">Service catalog and Plan composition</a>
               </li>
             </ul>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-5-0/operating.html#broker-management">Broker Management</a>
+            <a href="/on-demand-service-broker/0.5.0/operating.html#broker-management">Broker Management</a>
 
             <ul>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-5-0/operating.html#register-broker">register-broker</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-5-0/operating.html#deregister-broker">deregister-broker</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-5-0/operating.html#administering-instances">Administering service instances</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-5-0/operating.html#upgrading-the-broker">Upgrading the broker</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-5-0/operating.html#upgrading-existing-service-instances">Upgrading existing service instances</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-5-0/operating.html#deleting-all-service-instances">Deleting all service instances</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-5-0/operating.html#updating-service-plans">Updating service plans</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-5-0/operating.html#disabling-service-plans">Disabling service plans</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-5-0/operating.html#removing-service-plans">Removing service plans</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.5.0/operating.html#register-broker">register-broker</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.5.0/operating.html#deregister-broker">deregister-broker</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.5.0/operating.html#administering-instances">Administering service instances</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.5.0/operating.html#upgrading-the-broker">Upgrading the broker</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.5.0/operating.html#upgrading-existing-service-instances">Upgrading existing service instances</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.5.0/operating.html#deleting-all-service-instances">Deleting all service instances</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.5.0/operating.html#updating-service-plans">Updating service plans</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.5.0/operating.html#disabling-service-plans">Disabling service plans</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.5.0/operating.html#removing-service-plans">Removing service plans</a></span></li>
             </ul>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-5-0/operating.html#security">Security</a>
+            <a href="/on-demand-service-broker/0.5.0/operating.html#security">Security</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/operating.html#bosh-api-endpoints">BOSH API Endpoints</a>
+                <a href="/on-demand-service-broker/0.5.0/operating.html#bosh-api-endpoints">BOSH API Endpoints</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/operating.html#bosh-uaa-permissions">BOSH UAA permissions</a>
+                <a href="/on-demand-service-broker/0.5.0/operating.html#bosh-uaa-permissions">BOSH UAA permissions</a>
               </li>
             </ul>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-5-0/operating.html#troubleshooting">Troubleshooting</a>
+            <a href="/on-demand-service-broker/0.5.0/operating.html#troubleshooting">Troubleshooting</a>
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/operating.html#logs">Logs</a>
+                <a href="/on-demand-service-broker/0.5.0/operating.html#logs">Logs</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/operating.html#identifying-deployments">Identifying deployments in BOSH</a>
+                <a href="/on-demand-service-broker/0.5.0/operating.html#identifying-deployments">Identifying deployments in BOSH</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/operating.html#identifying-tasks">Identifying BOSH tasks</a>
+                <a href="/on-demand-service-broker/0.5.0/operating.html#identifying-tasks">Identifying BOSH tasks</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/operating.html#identifying-bosh-uaa-issues">Identifying issues with connecting to BOSH and/or UAA</a>
+                <a href="/on-demand-service-broker/0.5.0/operating.html#identifying-bosh-uaa-issues">Identifying issues with connecting to BOSH and/or UAA</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-5-0/operating.html#listing-service-instances">Listing service instances</a>
+                <a href="/on-demand-service-broker/0.5.0/operating.html#listing-service-instances">Listing service instances</a>
               </li>
             </ul>
           </li>
@@ -195,49 +195,49 @@
       </li>
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-5-0/tile.html">Creating a PCF OpsMan Tile</a>
+        <a href="/on-demand-service-broker/0.5.0/tile.html">Creating a PCF OpsMan Tile</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/tile.html#requirements">Requirements</a>
+            <a href="/on-demand-service-broker/0.5.0/tile.html#requirements">Requirements</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/tile.html#deploying">Deploying OpsMan to AWS</a>
+            <a href="/on-demand-service-broker/0.5.0/tile.html#deploying">Deploying OpsMan to AWS</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/tile.html#building">Building a tile</a>
+            <a href="/on-demand-service-broker/0.5.0/tile.html#building">Building a tile</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/tile.html#accessors">Non exhaustive Accessors Reference</a>
+            <a href="/on-demand-service-broker/0.5.0/tile.html#accessors">Non exhaustive Accessors Reference</a>
           </li>
         </ul>
       </li>
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-5-0/concepts.html">On-demand Service Broker Concepts/Reference</a>
+        <a href="/on-demand-service-broker/0.5.0/concepts.html">On-demand Service Broker Concepts/Reference</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/concepts.html#catalog">Catalog</a>
+            <a href="/on-demand-service-broker/0.5.0/concepts.html#catalog">Catalog</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/concepts.html#create-service-instance">Create service instance</a>
+            <a href="/on-demand-service-broker/0.5.0/concepts.html#create-service-instance">Create service instance</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/concepts.html#delete-service-instance">Delete service instance</a>
+            <a href="/on-demand-service-broker/0.5.0/concepts.html#delete-service-instance">Delete service instance</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/concepts.html#update-service-instance">Update service instance</a>
+            <a href="/on-demand-service-broker/0.5.0/concepts.html#update-service-instance">Update service instance</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/concepts.html#bind">Bind</a>
+            <a href="/on-demand-service-broker/0.5.0/concepts.html#bind">Bind</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/concepts.html#unbind">Unbind</a>
+            <a href="/on-demand-service-broker/0.5.0/concepts.html#unbind">Unbind</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/concepts.html#upgrade-all-instances">Upgrade all instances</a>
+            <a href="/on-demand-service-broker/0.5.0/concepts.html#upgrade-all-instances">Upgrade all instances</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-5-0/concepts.html#delete-all-instances">Delete all instances</a>
+            <a href="/on-demand-service-broker/0.5.0/concepts.html#delete-all-instances">Delete all instances</a>
           </li>
         </ul>
       </li>

--- a/master_middleman/source/subnavs/pivotal_on_demand_broker_subnav_v0-6-0.erb
+++ b/master_middleman/source/subnavs/pivotal_on_demand_broker_subnav_v0-6-0.erb
@@ -5,192 +5,192 @@
   <div class="nav-content deepnav-content">
     <ul>
       <li>
-        <a id='home-nav-link' href="/on-demand-service-broker-v0-6-0/index.html">On-demand Service Broker for Pivotal Cloud Foundry</a>
+        <a id='home-nav-link' href="/on-demand-service-broker/0.6.0/index.html">On-demand Service Broker for Pivotal Cloud Foundry</a>
       </li>
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-6-0/overview.html">Overview</a>
+        <a href="/on-demand-service-broker/0.6.0/overview.html">Overview</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/overview.html#what-is-a-cloud-foundry-service-broker">What is a Cloud Foundry service broker?</a>
+            <a href="/on-demand-service-broker/0.6.0/overview.html#what-is-a-cloud-foundry-service-broker">What is a Cloud Foundry service broker?</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/overview.html#what-is-an-on-demand-service-broker">What is an on-demand service broker?</a>
+            <a href="/on-demand-service-broker/0.6.0/overview.html#what-is-an-on-demand-service-broker">What is an on-demand service broker?</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/overview.html#what-is-a-service-adapter">What is a service adapter</a>
+            <a href="/on-demand-service-broker/0.6.0/overview.html#what-is-a-service-adapter">What is a service adapter</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/overview.html#why-provision-iaas-resources-on-demand">Why provision IAAS resources on-demand?</a>
+            <a href="/on-demand-service-broker/0.6.0/overview.html#why-provision-iaas-resources-on-demand">Why provision IAAS resources on-demand?</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/overview.html#why-use-odb-to-develop-on-demand-service-offerings">Why use ODB to develop on-demand service offerings?</a>
+            <a href="/on-demand-service-broker/0.6.0/overview.html#why-use-odb-to-develop-on-demand-service-offerings">Why use ODB to develop on-demand service offerings?</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-6-0/overview.html#prerequisites-for-deploying-brokers-that-use-odb">Prerequisites for deploying brokers that use ODB</a>
+            <a href="/on-demand-service-broker/0.6.0/overview.html#prerequisites-for-deploying-brokers-that-use-odb">Prerequisites for deploying brokers that use ODB</a>
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/overview.html#bosh-v2-features-we-use">BOSH v2 Features we use</a>
+                <a href="/on-demand-service-broker/0.6.0/overview.html#bosh-v2-features-we-use">BOSH v2 Features we use</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/overview.html#steps-required-to-use-on-demand-service-broker">Steps required to use on-demand service broker</a>
+            <a href="/on-demand-service-broker/0.6.0/overview.html#steps-required-to-use-on-demand-service-broker">Steps required to use on-demand service broker</a>
           </li>
         </ul>
       </li>
 
       <li>
-        <a href="/on-demand-service-broker-v0-6-0/getting-started.html">Setting up a local environment</a>
+        <a href="/on-demand-service-broker/0.6.0/getting-started.html">Setting up a local environment</a>
       </li>
 
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-6-0/creating.html">Creating a service adapter</a>
+        <a href="/on-demand-service-broker/0.6.0/creating.html">Creating a service adapter</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/creating.html#what-is-required-of-the-service-authors">What is required of the Service Authors?</a>
+            <a href="/on-demand-service-broker/0.6.0/creating.html#what-is-required-of-the-service-authors">What is required of the Service Authors?</a>
           </li>
           <li
-            <a href="/on-demand-service-broker-v0-6-0/creating.html#creating-a-service-release">Creating a Service Release</a>
+            <a href="/on-demand-service-broker/0.6.0/creating.html#creating-a-service-release">Creating a Service Release</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-6-0/creating.html#creating-a-service-adapter">Creating a Service Adapter</a>
+            <a href="/on-demand-service-broker/0.6.0/creating.html#creating-a-service-adapter">Creating a Service Adapter</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/creating.html#handling-errors">Handling errors</a>
+                <a href="/on-demand-service-broker/0.6.0/creating.html#handling-errors">Handling errors</a>
               </li>
             </ul>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-6-0/creating.html#inputs-for-manifest-generation">Inputs for manifest generation</a>
+            <a href="/on-demand-service-broker/0.6.0/creating.html#inputs-for-manifest-generation">Inputs for manifest generation</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/creating.html#arbitrary-parameters">Arbitrary parameters</a>
+                <a href="/on-demand-service-broker/0.6.0/creating.html#arbitrary-parameters">Arbitrary parameters</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/creating.html#previous-manifest-properties">Previous manifest properties</a>
+                <a href="/on-demand-service-broker/0.6.0/creating.html#previous-manifest-properties">Previous manifest properties</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/creating.html#service-plan-properties">Service plan properties</a>
+                <a href="/on-demand-service-broker/0.6.0/creating.html#service-plan-properties">Service plan properties</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/creating.html#order-of-precedence">Order of precedence</a>
+                <a href="/on-demand-service-broker/0.6.0/creating.html#order-of-precedence">Order of precedence</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/creating.html#service-adapter-interface">Service adapter interface</a>
+            <a href="/on-demand-service-broker/0.6.0/creating.html#service-adapter-interface">Service adapter interface</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-6-0/creating.html#sub-commands">Subcommands</a>
+            <a href="/on-demand-service-broker/0.6.0/creating.html#sub-commands">Subcommands</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/creating.html#generate-manifest">generate-manifest</a>
+                <a href="/on-demand-service-broker/0.6.0/creating.html#generate-manifest">generate-manifest</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/creating.html#dashboard-url">dashboard-url</a>
+                <a href="/on-demand-service-broker/0.6.0/creating.html#dashboard-url">dashboard-url</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/creating.html#create-binding">create-binding</a>
+                <a href="/on-demand-service-broker/0.6.0/creating.html#create-binding">create-binding</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/creating.html#delete-binding">delete-binding</a>
+                <a href="/on-demand-service-broker/0.6.0/creating.html#delete-binding">delete-binding</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/creating.html#packaging">Packaging</a>
+            <a href="/on-demand-service-broker/0.6.0/creating.html#packaging">Packaging</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/creating.html#sdk">Golang SDK</a>
+            <a href="/on-demand-service-broker/0.6.0/creating.html#sdk">Golang SDK</a>
           </li>
         </ul>
       </li>
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-6-0/operating.html">Operating the On-demand Service Broker</a>
+        <a href="/on-demand-service-broker/0.6.0/operating.html">Operating the On-demand Service Broker</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/operating.html#what-are-the-responsibilities-of-the-operator">What are the responsibilities of the Operator?</a>
+            <a href="/on-demand-service-broker/0.6.0/operating.html#what-are-the-responsibilities-of-the-operator">What are the responsibilities of the Operator?</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-6-0/operating.html#configure-bosh">Setting up your BOSH director</a>
+            <a href="/on-demand-service-broker/0.6.0/operating.html#configure-bosh">Setting up your BOSH director</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/operating.html#ssl-certificates">SSL certificates</a>
+                <a href="/on-demand-service-broker/0.6.0/operating.html#ssl-certificates">SSL certificates</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/operating.html#bosh-teams">BOSH teams</a>
+                <a href="/on-demand-service-broker/0.6.0/operating.html#bosh-teams">BOSH teams</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/operating.html#upload-required-releases">Upload Required Releases</a>
+            <a href="/on-demand-service-broker/0.6.0/operating.html#upload-required-releases">Upload Required Releases</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-6-0/operating.html#write-a-broker-manifest">Write a Broker Manifest</a>
+            <a href="/on-demand-service-broker/0.6.0/operating.html#write-a-broker-manifest">Write a Broker Manifest</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/operating.html#core-broker-configuration">Core Broker Configuration</a>
+                <a href="/on-demand-service-broker/0.6.0/operating.html#core-broker-configuration">Core Broker Configuration</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/operating.html#service-catalog-and-plan-composition">Service catalog and Plan composition</a>
+                <a href="/on-demand-service-broker/0.6.0/operating.html#service-catalog-and-plan-composition">Service catalog and Plan composition</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/operating.html#route-registration">Route registration</a>
+                <a href="/on-demand-service-broker/0.6.0/operating.html#route-registration">Route registration</a>
               </li>
             </ul>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-6-0/operating.html#broker-management">Broker Management</a>
+            <a href="/on-demand-service-broker/0.6.0/operating.html#broker-management">Broker Management</a>
 
             <ul>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-6-0/operating.html#register-broker">register-broker</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-6-0/operating.html#deregister-broker">deregister-broker</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-6-0/operating.html#administering-instances">Administering service instances</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-6-0/operating.html#upgrading-the-broker">Upgrading the broker</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-6-0/operating.html#upgrading-existing-service-instances">Upgrading existing service instances</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-6-0/operating.html#deleting-all-service-instances">Deleting all service instances</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-6-0/operating.html#updating-service-plans">Updating service plans</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-6-0/operating.html#disabling-service-plans">Disabling service plans</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-6-0/operating.html#removing-service-plans">Removing service plans</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.6.0/operating.html#register-broker">register-broker</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.6.0/operating.html#deregister-broker">deregister-broker</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.6.0/operating.html#administering-instances">Administering service instances</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.6.0/operating.html#upgrading-the-broker">Upgrading the broker</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.6.0/operating.html#upgrading-existing-service-instances">Upgrading existing service instances</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.6.0/operating.html#deleting-all-service-instances">Deleting all service instances</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.6.0/operating.html#updating-service-plans">Updating service plans</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.6.0/operating.html#disabling-service-plans">Disabling service plans</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.6.0/operating.html#removing-service-plans">Removing service plans</a></span></li>
             </ul>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-6-0/operating.html#security">Security</a>
+            <a href="/on-demand-service-broker/0.6.0/operating.html#security">Security</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/operating.html#bosh-api-endpoints">BOSH API Endpoints</a>
+                <a href="/on-demand-service-broker/0.6.0/operating.html#bosh-api-endpoints">BOSH API Endpoints</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/operating.html#bosh-uaa-permissions">BOSH UAA permissions</a>
+                <a href="/on-demand-service-broker/0.6.0/operating.html#bosh-uaa-permissions">BOSH UAA permissions</a>
               </li>
             </ul>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-6-0/operating.html#troubleshooting">Troubleshooting</a>
+            <a href="/on-demand-service-broker/0.6.0/operating.html#troubleshooting">Troubleshooting</a>
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/operating.html#logs">Logs</a>
+                <a href="/on-demand-service-broker/0.6.0/operating.html#logs">Logs</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/operating.html#identifying-deployments">Identifying deployments in BOSH</a>
+                <a href="/on-demand-service-broker/0.6.0/operating.html#identifying-deployments">Identifying deployments in BOSH</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/operating.html#identifying-tasks">Identifying BOSH tasks</a>
+                <a href="/on-demand-service-broker/0.6.0/operating.html#identifying-tasks">Identifying BOSH tasks</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/operating.html#identifying-bosh-uaa-issues">Identifying issues with connecting to BOSH and/or UAA</a>
+                <a href="/on-demand-service-broker/0.6.0/operating.html#identifying-bosh-uaa-issues">Identifying issues with connecting to BOSH and/or UAA</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-6-0/operating.html#listing-service-instances">Listing service instances</a>
+                <a href="/on-demand-service-broker/0.6.0/operating.html#listing-service-instances">Listing service instances</a>
               </li>
             </ul>
           </li>
@@ -198,49 +198,49 @@
       </li>
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-6-0/tile.html">Creating a PCF OpsMan Tile</a>
+        <a href="/on-demand-service-broker/0.6.0/tile.html">Creating a PCF OpsMan Tile</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/tile.html#requirements">Requirements</a>
+            <a href="/on-demand-service-broker/0.6.0/tile.html#requirements">Requirements</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/tile.html#deploying">Deploying OpsMan to AWS</a>
+            <a href="/on-demand-service-broker/0.6.0/tile.html#deploying">Deploying OpsMan to AWS</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/tile.html#building">Building a tile</a>
+            <a href="/on-demand-service-broker/0.6.0/tile.html#building">Building a tile</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/tile.html#accessors">Non exhaustive Accessors Reference</a>
+            <a href="/on-demand-service-broker/0.6.0/tile.html#accessors">Non exhaustive Accessors Reference</a>
           </li>
         </ul>
       </li>
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-6-0/concepts.html">On-demand Service Broker Concepts/Reference</a>
+        <a href="/on-demand-service-broker/0.6.0/concepts.html">On-demand Service Broker Concepts/Reference</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/concepts.html#catalog">Catalog</a>
+            <a href="/on-demand-service-broker/0.6.0/concepts.html#catalog">Catalog</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/concepts.html#create-service-instance">Create service instance</a>
+            <a href="/on-demand-service-broker/0.6.0/concepts.html#create-service-instance">Create service instance</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/concepts.html#delete-service-instance">Delete service instance</a>
+            <a href="/on-demand-service-broker/0.6.0/concepts.html#delete-service-instance">Delete service instance</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/concepts.html#update-service-instance">Update service instance</a>
+            <a href="/on-demand-service-broker/0.6.0/concepts.html#update-service-instance">Update service instance</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/concepts.html#bind">Bind</a>
+            <a href="/on-demand-service-broker/0.6.0/concepts.html#bind">Bind</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/concepts.html#unbind">Unbind</a>
+            <a href="/on-demand-service-broker/0.6.0/concepts.html#unbind">Unbind</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/concepts.html#upgrade-all-instances">Upgrade all instances</a>
+            <a href="/on-demand-service-broker/0.6.0/concepts.html#upgrade-all-instances">Upgrade all instances</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-6-0/concepts.html#delete-all-instances">Delete all instances</a>
+            <a href="/on-demand-service-broker/0.6.0/concepts.html#delete-all-instances">Delete all instances</a>
           </li>
         </ul>
       </li>

--- a/master_middleman/source/subnavs/pivotal_on_demand_broker_subnav_v0-7-0.erb
+++ b/master_middleman/source/subnavs/pivotal_on_demand_broker_subnav_v0-7-0.erb
@@ -5,192 +5,192 @@
   <div class="nav-content deepnav-content">
     <ul>
       <li>
-        <a id='home-nav-link' href="/on-demand-service-broker-v0-7-0/index.html">On-demand Service Broker for Pivotal Cloud Foundry</a>
+        <a id='home-nav-link' href="/on-demand-service-broker/0.7.0/index.html">On-demand Service Broker for Pivotal Cloud Foundry</a>
       </li>
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-7-0/overview.html">Overview</a>
+        <a href="/on-demand-service-broker/0.7.0/overview.html">Overview</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/overview.html#what-is-a-cloud-foundry-service-broker">What is a Cloud Foundry service broker?</a>
+            <a href="/on-demand-service-broker/0.7.0/overview.html#what-is-a-cloud-foundry-service-broker">What is a Cloud Foundry service broker?</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/overview.html#what-is-an-on-demand-service-broker">What is an on-demand service broker?</a>
+            <a href="/on-demand-service-broker/0.7.0/overview.html#what-is-an-on-demand-service-broker">What is an on-demand service broker?</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/overview.html#what-is-a-service-adapter">What is a service adapter</a>
+            <a href="/on-demand-service-broker/0.7.0/overview.html#what-is-a-service-adapter">What is a service adapter</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/overview.html#why-provision-iaas-resources-on-demand">Why provision IAAS resources on-demand?</a>
+            <a href="/on-demand-service-broker/0.7.0/overview.html#why-provision-iaas-resources-on-demand">Why provision IAAS resources on-demand?</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/overview.html#why-use-odb-to-develop-on-demand-service-offerings">Why use ODB to develop on-demand service offerings?</a>
+            <a href="/on-demand-service-broker/0.7.0/overview.html#why-use-odb-to-develop-on-demand-service-offerings">Why use ODB to develop on-demand service offerings?</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-7-0/overview.html#prerequisites-for-deploying-brokers-that-use-odb">Prerequisites for deploying brokers that use ODB</a>
+            <a href="/on-demand-service-broker/0.7.0/overview.html#prerequisites-for-deploying-brokers-that-use-odb">Prerequisites for deploying brokers that use ODB</a>
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/overview.html#bosh-v2-features-we-use">BOSH v2 Features we use</a>
+                <a href="/on-demand-service-broker/0.7.0/overview.html#bosh-v2-features-we-use">BOSH v2 Features we use</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/overview.html#steps-required-to-use-on-demand-service-broker">Steps required to use on-demand service broker</a>
+            <a href="/on-demand-service-broker/0.7.0/overview.html#steps-required-to-use-on-demand-service-broker">Steps required to use on-demand service broker</a>
           </li>
         </ul>
       </li>
 
       <li>
-        <a href="/on-demand-service-broker-v0-7-0/getting-started.html">Setting up a local environment</a>
+        <a href="/on-demand-service-broker/0.7.0/getting-started.html">Setting up a local environment</a>
       </li>
 
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-7-0/creating.html">Creating a service adapter</a>
+        <a href="/on-demand-service-broker/0.7.0/creating.html">Creating a service adapter</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/creating.html#what-is-required-of-the-service-authors">What is required of the Service Authors?</a>
+            <a href="/on-demand-service-broker/0.7.0/creating.html#what-is-required-of-the-service-authors">What is required of the Service Authors?</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/creating.html#creating-a-service-release">Creating a Service Release</a>
+            <a href="/on-demand-service-broker/0.7.0/creating.html#creating-a-service-release">Creating a Service Release</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-7-0/creating.html#creating-a-service-adapter">Creating a Service Adapter</a>
+            <a href="/on-demand-service-broker/0.7.0/creating.html#creating-a-service-adapter">Creating a Service Adapter</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/creating.html#handling-errors">Handling errors</a>
+                <a href="/on-demand-service-broker/0.7.0/creating.html#handling-errors">Handling errors</a>
               </li>
             </ul>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-7-0/creating.html#inputs-for-manifest-generation">Inputs for manifest generation</a>
+            <a href="/on-demand-service-broker/0.7.0/creating.html#inputs-for-manifest-generation">Inputs for manifest generation</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/creating.html#arbitrary-parameters">Arbitrary parameters</a>
+                <a href="/on-demand-service-broker/0.7.0/creating.html#arbitrary-parameters">Arbitrary parameters</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/creating.html#previous-manifest-properties">Previous manifest properties</a>
+                <a href="/on-demand-service-broker/0.7.0/creating.html#previous-manifest-properties">Previous manifest properties</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/creating.html#service-plan-properties">Service plan properties</a>
+                <a href="/on-demand-service-broker/0.7.0/creating.html#service-plan-properties">Service plan properties</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/creating.html#order-of-precedence">Order of precedence</a>
+                <a href="/on-demand-service-broker/0.7.0/creating.html#order-of-precedence">Order of precedence</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/creating.html#service-adapter-interface">Service adapter interface</a>
+            <a href="/on-demand-service-broker/0.7.0/creating.html#service-adapter-interface">Service adapter interface</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-7-0/creating.html#sub-commands">Subcommands</a>
+            <a href="/on-demand-service-broker/0.7.0/creating.html#sub-commands">Subcommands</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/creating.html#generate-manifest">generate-manifest</a>
+                <a href="/on-demand-service-broker/0.7.0/creating.html#generate-manifest">generate-manifest</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/creating.html#dashboard-url">dashboard-url</a>
+                <a href="/on-demand-service-broker/0.7.0/creating.html#dashboard-url">dashboard-url</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/creating.html#create-binding">create-binding</a>
+                <a href="/on-demand-service-broker/0.7.0/creating.html#create-binding">create-binding</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/creating.html#delete-binding">delete-binding</a>
+                <a href="/on-demand-service-broker/0.7.0/creating.html#delete-binding">delete-binding</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/creating.html#packaging">Packaging</a>
+            <a href="/on-demand-service-broker/0.7.0/creating.html#packaging">Packaging</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/creating.html#sdk">Golang SDK</a>
+            <a href="/on-demand-service-broker/0.7.0/creating.html#sdk">Golang SDK</a>
           </li>
         </ul>
       </li>
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-7-0/operating.html">Operating the On-demand Service Broker</a>
+        <a href="/on-demand-service-broker/0.7.0/operating.html">Operating the On-demand Service Broker</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/operating.html#what-are-the-responsibilities-of-the-operator">What are the responsibilities of the Operator?</a>
+            <a href="/on-demand-service-broker/0.7.0/operating.html#what-are-the-responsibilities-of-the-operator">What are the responsibilities of the Operator?</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-7-0/operating.html#configure-bosh">Setting up your BOSH director</a>
+            <a href="/on-demand-service-broker/0.7.0/operating.html#configure-bosh">Setting up your BOSH director</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/operating.html#ssl-certificates">SSL certificates</a>
+                <a href="/on-demand-service-broker/0.7.0/operating.html#ssl-certificates">SSL certificates</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/operating.html#bosh-teams">BOSH teams</a>
+                <a href="/on-demand-service-broker/0.7.0/operating.html#bosh-teams">BOSH teams</a>
               </li>
             </ul>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/operating.html#upload-required-releases">Upload Required Releases</a>
+            <a href="/on-demand-service-broker/0.7.0/operating.html#upload-required-releases">Upload Required Releases</a>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-7-0/operating.html#write-a-broker-manifest">Write a Broker Manifest</a>
+            <a href="/on-demand-service-broker/0.7.0/operating.html#write-a-broker-manifest">Write a Broker Manifest</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/operating.html#core-broker-configuration">Core Broker Configuration</a>
+                <a href="/on-demand-service-broker/0.7.0/operating.html#core-broker-configuration">Core Broker Configuration</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/operating.html#service-catalog-and-plan-composition">Service catalog and Plan composition</a>
+                <a href="/on-demand-service-broker/0.7.0/operating.html#service-catalog-and-plan-composition">Service catalog and Plan composition</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/operating.html#route-registration">Route registration</a>
+                <a href="/on-demand-service-broker/0.7.0/operating.html#route-registration">Route registration</a>
               </li>
             </ul>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-7-0/operating.html#broker-management">Broker Management</a>
+            <a href="/on-demand-service-broker/0.7.0/operating.html#broker-management">Broker Management</a>
 
             <ul>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-7-0/operating.html#register-broker">register-broker</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-7-0/operating.html#deregister-broker">deregister-broker</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-7-0/operating.html#administering-instances">Administering service instances</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-7-0/operating.html#upgrading-the-broker">Upgrading the broker</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-7-0/operating.html#upgrading-existing-service-instances">Upgrading existing service instances</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-7-0/operating.html#deleting-all-service-instances">Deleting all service instances</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-7-0/operating.html#updating-service-plans">Updating service plans</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-7-0/operating.html#disabling-service-plans">Disabling service plans</a></span></li>
-                <li><span class="topic"><a href="/on-demand-service-broker-v0-7-0/operating.html#removing-service-plans">Removing service plans</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.7.0/operating.html#register-broker">register-broker</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.7.0/operating.html#deregister-broker">deregister-broker</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.7.0/operating.html#administering-instances">Administering service instances</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.7.0/operating.html#upgrading-the-broker">Upgrading the broker</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.7.0/operating.html#upgrading-existing-service-instances">Upgrading existing service instances</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.7.0/operating.html#deleting-all-service-instances">Deleting all service instances</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.7.0/operating.html#updating-service-plans">Updating service plans</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.7.0/operating.html#disabling-service-plans">Disabling service plans</a></span></li>
+                <li><span class="topic"><a href="/on-demand-service-broker/0.7.0/operating.html#removing-service-plans">Removing service plans</a></span></li>
             </ul>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-7-0/operating.html#security">Security</a>
+            <a href="/on-demand-service-broker/0.7.0/operating.html#security">Security</a>
 
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/operating.html#bosh-api-endpoints">BOSH API Endpoints</a>
+                <a href="/on-demand-service-broker/0.7.0/operating.html#bosh-api-endpoints">BOSH API Endpoints</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/operating.html#bosh-uaa-permissions">BOSH UAA permissions</a>
+                <a href="/on-demand-service-broker/0.7.0/operating.html#bosh-uaa-permissions">BOSH UAA permissions</a>
               </li>
             </ul>
           </li>
           <li class="has_submenu">
-            <a href="/on-demand-service-broker-v0-7-0/operating.html#troubleshooting">Troubleshooting</a>
+            <a href="/on-demand-service-broker/0.7.0/operating.html#troubleshooting">Troubleshooting</a>
             <ul>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/operating.html#logs">Logs</a>
+                <a href="/on-demand-service-broker/0.7.0/operating.html#logs">Logs</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/operating.html#identifying-deployments">Identifying deployments in BOSH</a>
+                <a href="/on-demand-service-broker/0.7.0/operating.html#identifying-deployments">Identifying deployments in BOSH</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/operating.html#identifying-tasks">Identifying BOSH tasks</a>
+                <a href="/on-demand-service-broker/0.7.0/operating.html#identifying-tasks">Identifying BOSH tasks</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/operating.html#identifying-bosh-uaa-issues">Identifying issues with connecting to BOSH and/or UAA</a>
+                <a href="/on-demand-service-broker/0.7.0/operating.html#identifying-bosh-uaa-issues">Identifying issues with connecting to BOSH and/or UAA</a>
               </li>
               <li>
-                <a href="/on-demand-service-broker-v0-7-0/operating.html#listing-service-instances">Listing service instances</a>
+                <a href="/on-demand-service-broker/0.7.0/operating.html#listing-service-instances">Listing service instances</a>
               </li>
             </ul>
           </li>
@@ -198,49 +198,49 @@
       </li>
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-7-0/tile.html">Creating a PCF OpsMan Tile</a>
+        <a href="/on-demand-service-broker/0.7.0/tile.html">Creating a PCF OpsMan Tile</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/tile.html#requirements">Requirements</a>
+            <a href="/on-demand-service-broker/0.7.0/tile.html#requirements">Requirements</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/tile.html#deploying">Deploying OpsMan to AWS</a>
+            <a href="/on-demand-service-broker/0.7.0/tile.html#deploying">Deploying OpsMan to AWS</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/tile.html#building">Building a tile</a>
+            <a href="/on-demand-service-broker/0.7.0/tile.html#building">Building a tile</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/tile.html#accessors">Non exhaustive Accessors Reference</a>
+            <a href="/on-demand-service-broker/0.7.0/tile.html#accessors">Non exhaustive Accessors Reference</a>
           </li>
         </ul>
       </li>
 
       <li class="has_submenu">
-        <a href="/on-demand-service-broker-v0-7-0/concepts.html">On-demand Service Broker Concepts/Reference</a>
+        <a href="/on-demand-service-broker/0.7.0/concepts.html">On-demand Service Broker Concepts/Reference</a>
         <ul>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/concepts.html#catalog">Catalog</a>
+            <a href="/on-demand-service-broker/0.7.0/concepts.html#catalog">Catalog</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/concepts.html#create-service-instance">Create service instance</a>
+            <a href="/on-demand-service-broker/0.7.0/concepts.html#create-service-instance">Create service instance</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/concepts.html#delete-service-instance">Delete service instance</a>
+            <a href="/on-demand-service-broker/0.7.0/concepts.html#delete-service-instance">Delete service instance</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/concepts.html#update-service-instance">Update service instance</a>
+            <a href="/on-demand-service-broker/0.7.0/concepts.html#update-service-instance">Update service instance</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/concepts.html#bind">Bind</a>
+            <a href="/on-demand-service-broker/0.7.0/concepts.html#bind">Bind</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/concepts.html#unbind">Unbind</a>
+            <a href="/on-demand-service-broker/0.7.0/concepts.html#unbind">Unbind</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/concepts.html#upgrade-all-instances">Upgrade all instances</a>
+            <a href="/on-demand-service-broker/0.7.0/concepts.html#upgrade-all-instances">Upgrade all instances</a>
           </li>
           <li>
-            <a href="/on-demand-service-broker-v0-7-0/concepts.html#delete-all-instances">Delete all instances</a>
+            <a href="/on-demand-service-broker/0.7.0/concepts.html#delete-all-instances">Delete all instances</a>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
**This changes config.yml so you may have to reconfigure concourse pipelines to test this**

As well as releasing ODB 0.8.0 (which now uses autogenerated subnav), this also migrates all our old versions to use local headers, so this is a rather big PR!

Let us know if there are any issues.

We're making a related PR in docs-layout-repo that removes our custom header.

Cheers,
Craig

cc @avade 
