### PR TITLE
use v0.8.x branch for ODB v0.8.0

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -224,7 +224,7 @@ sections:
   subnav_template: pivotal_new_relic_service_subnav.erb
 - repository:
     name: pivotal-cf/docs-on-demand-service-broker
-    ref: v0.8.0
+    ref: v0.8.x
   directory: on-demand-service-broker/0.8.0
   product_id: odb-v0-8-0
   product_info:


### PR DESCRIPTION
Apparently there are issues with ODB's docs repo, so I've pushed a branch at the v0.8.0 tag's current SHA so that we can track attempts to fix it in a shareable way rather than modifying tags.

cc @avade @seviet @abbyachau 
