### PR TITLE
Enable links to AppDog install docs

### DIFF
--- a/master_middleman/source/subnavs/appdog.erb
+++ b/master_middleman/source/subnavs/appdog.erb
@@ -7,15 +7,9 @@
       <li>
         <a id='home-nav-link' href="/pcf-appdog/index.html">PCF Application Watchdog</a>
       </li>
-      <!-- Remove comments when the PCF appdog tile is approved/available.
       <li>
-        <a id='home-nav-link' href="/appdog/installing.html">Installing PCF Application Watchdog</a>
+        <a id='home-nav-link' href="/pcf-appdog/install.html">Installing PCF Application Watchdog</a>
       </li>
-      -->
-      <!--<li>
-        <a id='home-nav-link' href="/pcf-appdog/using.html">Using PCF Application Watchdog</a>
-      </li>
-      -->
       <li>
         <a id='home-nav-link' href="/pcf-appdog/rn-ki.html">Release Notes and Known Issues</a>
       </li>


### PR DESCRIPTION
We've added install docs in prep. for the tile release.
