### PR TITLE
Fix rabbitmq dark-launch URL path

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -411,7 +411,7 @@ sections:
 - repository:
     name: pivotal-cf/docs-rabbitmq-staging
     ref: 'master'
-  directory: rabbitmq-cf/d34379b0-a290-47c7-bc6c-c45a9adfa8c7
+  directory: rabbitmq-cf-d34379b0-a290-47c7-bc6c-c45a9adfa8c7
   subnav_template: pivotal_rabbitmq_service_subnav-unreleased.erb
   product_info:
     use_local_header: true
@@ -419,7 +419,7 @@ sections:
     local_header_img: /images/cloud_rings.png
     local_header_title: RabbitMQ for PCF
     search_placeholder: Search RabbitMQ 1.8.0
-    url_prefix: rabbitmq-cf/d34379b0-a290-47c7-bc6c-c45a9adfa8c7
+    url_prefix: rabbitmq-cf-d34379b0-a290-47c7-bc6c-c45a9adfa8c7
     local_product_version: 1.8.0
     local_header_links: []
     local_header_version_list:

--- a/master_middleman/source/subnavs/pivotal_rabbitmq_service_subnav-unreleased.erb
+++ b/master_middleman/source/subnavs/pivotal_rabbitmq_service_subnav-unreleased.erb
@@ -6,51 +6,51 @@
   <div class="nav-content">
     <ul>
       <li>
-        <a href="/rabbitmq-cf/<%= @version_for_url_path %>/index.html">RabbitMQ&reg; for PCF</a>
+        <a href="/rabbitmq-cf-<%= @version_for_url_path %>/index.html">RabbitMQ&reg; for PCF</a>
       </li>
 
       <li>
-        <a href="/rabbitmq-cf/<%= @version_for_url_path %>/deploying.html">Deploying</a>
+        <a href="/rabbitmq-cf-<%= @version_for_url_path %>/deploying.html">Deploying</a>
       </li>
 
       <li>
-        <a href="/rabbitmq-cf/<%= @version_for_url_path %>/upgrade.html">Upgrades</a>
+        <a href="/rabbitmq-cf-<%= @version_for_url_path %>/upgrade.html">Upgrades</a>
       </li>
 
       <li>
-        <a href="/rabbitmq-cf/<%= @version_for_url_path %>/configuring.html">Configuring</a>
+        <a href="/rabbitmq-cf-<%= @version_for_url_path %>/configuring.html">Configuring</a>
       </li>
 
       <li>
-        <a href="/rabbitmq-cf/<%= @version_for_url_path %>/policies.html">Policies</a>
+        <a href="/rabbitmq-cf-<%= @version_for_url_path %>/policies.html">Policies</a>
       </li>
 
       <li>
-        <a href="/rabbitmq-cf/<%= @version_for_url_path %>/partitions.html">Clustering and Network Partitions</a>
+        <a href="/rabbitmq-cf-<%= @version_for_url_path %>/partitions.html">Clustering and Network Partitions</a>
       </li>
 
       <li>
-        <a href="/rabbitmq-cf/<%= @version_for_url_path %>/managing.html">Managing</a>
+        <a href="/rabbitmq-cf-<%= @version_for_url_path %>/managing.html">Managing</a>
       </li>
 
       <li>
-        <a href="/rabbitmq-cf/<%= @version_for_url_path %>/metrics_logging.html">Logging, Heartbeats, and Metrics</a>
+        <a href="/rabbitmq-cf-<%= @version_for_url_path %>/metrics_logging.html">Logging, Heartbeats, and Metrics</a>
       </li>
 
       <li>
-        <a href="/rabbitmq-cf/<%= @version_for_url_path %>/vcap-services.html">Environment Variables</a>
+        <a href="/rabbitmq-cf-<%= @version_for_url_path %>/vcap-services.html">Environment Variables</a>
       </li>
 
       <li>
-        <a href="/rabbitmq-cf/<%= @version_for_url_path %>/releases.html">Release Notes</a>
+        <a href="/rabbitmq-cf-<%= @version_for_url_path %>/releases.html">Release Notes</a>
       </li>
 
       <li>
-        <a href="/rabbitmq-cf/<%= @version_for_url_path %>/resources.html">Resource Requirements</a>
+        <a href="/rabbitmq-cf-<%= @version_for_url_path %>/resources.html">Resource Requirements</a>
       </li>
 
       <li>
-        <a href="/rabbitmq-cf/<%= @version_for_url_path %>/on_demand_broker.html">Configuring and Managing RabbitMQ Dedicated Instances - Experimental</a>
+        <a href="/rabbitmq-cf-<%= @version_for_url_path %>/on_demand_broker.html">Configuring and Managing RabbitMQ Dedicated Instances - Experimental</a>
       </li>
 
     </ul>


### PR DESCRIPTION
- using a path that does not conflict with redirects.rb. I believe that
  making a sub-dir of rabbitmq-cf would require a bit more complexity of
  regex foo in order to make it work. Hopeing the simple solution works
  effectively. This was tested localy.