### PR TITLE
Fix an issue with redirect when hitting the push api docs

### DIFF
--- a/redirects.rb
+++ b/redirects.rb
@@ -98,7 +98,7 @@ r301 %r{/mobile/notifications/(.*)}, '/push/'
 r301 %r{/mobile/app_distribution/(.*)}, '/app-dist/'
 r301 %r{/mobile/push/(.*)}, '/push/'
 r301 'v1_6_0/api/tags/index.html', '/v1_6_0/api/topics/index.html'
-r301 %r{/push/(?![\d-]+)(.*)}, "/push/1-7/$1"
+r301 %r{^/push/(?![\d-]+)(.*)}, "/push/1-7/$1"
 
 r301 %r{/pivotalcf/packaging/(.*)}, '/tiledev/$1'
 r301 %r{/pivotalcf/partners/(.*)}, '/tiledev/$1'


### PR DESCRIPTION
Noticed that the old redirect rule would match when we hit https://docs.pivotal.io/push/1-7/api/push/push.html , and redirect to a non-existing page.

The new rule should no longer match the "/push" in the middle of the url.