### PR TITLE
Added trailing slash for regular expression

### DIFF
--- a/redirects.rb
+++ b/redirects.rb
@@ -663,7 +663,7 @@ r301 %r{/platform/(2-[7-9]|2-\d\d+)/healthwatch/(.*)}, '/healthwatch/$1'
 r301 %r{/pivotalcf/(?![\d-]+)(.*)}, '/platform/2-10/$1'
 
 # Reinstate versionless platform links
-r301 %r{/platform/opsman-api(?![\d-]+)(.*)}, '/platform/2-10/opsman-api/$1'
+r301 %r{/platform/opsman-api/(?![\d-]+)(.*)}, '/platform/2-10/opsman-api/$1'
 r301 %r{/platform/(?![\d-]+)(.*)}, '/platform/2-10/$1'
 
 r301 %r{/pivotalcf/(2-[7-9]|2-\d\d+)/(.*)}, '/platform/$1/$2'


### PR DESCRIPTION
The regular expression on this line is a negative look ahead.
It says, "as long as no numbers appear, then match the greed (.*) group".
It, however, does this when trying to match the trailing `/`, and borks.

Taking from the other redirects, we've added the trailing `/` in.