### PR TITLE
Updating Tanzu Build Service with link to v1.3 on VMware docs

### DIFF
--- a/master_middleman/source/index.html.erb
+++ b/master_middleman/source/index.html.erb
@@ -35,7 +35,7 @@ top_services:
   desc: Container creation and management
   links:
   - name: Tanzu Build Service
-    url: https://docs.pivotal.io/build-service
+    url: https://docs.vmware.com/en/VMware-Tanzu-Build-Service/index.html
   - name: Tanzu Buildpacks
     url: https://docs.pivotal.io/tanzu-buildpacks
 - name: Tanzu Application Catalog


### PR DESCRIPTION
Latest Tanzu Build Service and two earlier version are now on Docs and linked from the master Tanzu landing page.