### PR TITLE
greenplum nifi/spark connectors now on docs.vmware.com

### DIFF
--- a/master_middleman/source/index.html.erb
+++ b/master_middleman/source/index.html.erb
@@ -131,10 +131,10 @@ top_services:
     url: https://greenplum.docs.pivotal.io/pxf
   - name: Tanzu Greenplum<span class='tmr'>&reg; Data Copy Utility</span>
     url: https://greenplum.docs.pivotal.io/data-copy
-  - name: Tanzu Greenplum<span class='tmr'>&reg;</span> Connector for Apache Nifi<span class='tmr'>&trade;</span>
-    url: https://greenplum.docs.pivotal.io/connectors/apache-nifi
+  - name: Tanzu Greenplum<span class='tmr'>&reg;</span> Connector for Apache NiFi<span class='tmr'>&trade;</span>
+    url: https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Connector-for-Apache-NiFi/index.html
   - name: Tanzu Greenplum<span class='tmr'>&reg;</span> Connector for Apache Spark<span class='tmr'>&trade;</span>
-    url: https://greenplum-spark.docs.pivotal.io
+    url: https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Connector-for-Apache-Spark/index.html
   - name: Tanzu Greenplum<span class='tmr'>&reg; Connector for Informatica</span>
     url: https://greenplum-informatica.docs.pivotal.io
   - name: Tanzu Greenplum<span class='tmr'>&reg; Streaming Server</span>


### PR DESCRIPTION
update the greenplum nifi and spark connectors docs links to point to the specific connector landing page on docs.vmware.com.  left the informatica connector as-is (pointing to pivotal docs).