### PR TITLE
Changes Metrics Forwarder link to point to docs.vmware.com

### DIFF
--- a/master_middleman/source/index.html.erb
+++ b/master_middleman/source/index.html.erb
@@ -355,7 +355,7 @@ addon:
       url: https://docs.pivotal.io/metric-store/index.html
       logo: icon_pivotal_generic@2x.png
     - name: Metrics Forwarder <br>for PCF
-      url: https://docs.pivotal.io/metrics-forwarder/index.html
+      url: https://docs.vmware.com/en/Metrics-Forwarder/1.11/metrics-forwarder/GUID-index.html
       logo: icon_pivotal_generic@2x.png
     - name: Nozzle for VMware Tanzu<br>for Microsoft Azure Log Analytics
       url: https://docs.pivotal.io/partners/azure-log-analytics-nozzle/index.html


### PR DESCRIPTION
Migrated the Metrics Forwarder docs to docs.vmware.com. 