### PR TITLE
greenplum informatica connector docs link to vmdocs

### DIFF
--- a/master_middleman/source/index.html.erb
+++ b/master_middleman/source/index.html.erb
@@ -136,7 +136,7 @@ top_services:
   - name: Tanzu Greenplum<span class='tmr'>&reg;</span> Connector for Apache Spark<span class='tmr'>&trade;</span>
     url: https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Connector-for-Apache-Spark/index.html
   - name: Tanzu Greenplum<span class='tmr'>&reg; Connector for Informatica</span>
-    url: https://greenplum-informatica.docs.pivotal.io
+    url: https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Connector-for-Informatica/index.html
   - name: Tanzu Greenplum<span class='tmr'>&reg; Streaming Server</span>
     url: https://greenplum.docs.pivotal.io/streaming-server
   - name: Greenplum Database


### PR DESCRIPTION
merge after vmware tanzu greenplum connector for informatica docs are available on docs.vmware.com.