### PR TITLE
add greenplum/gemfire connector, redir to docs.vmware.com

### DIFF
--- a/master_middleman/source/index.html.erb
+++ b/master_middleman/source/index.html.erb
@@ -137,6 +137,8 @@ top_services:
     url: https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Connector-for-Apache-Spark/index.html
   - name: Tanzu Greenplum<span class='tmr'>&reg; Connector for Informatica</span>
     url: https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Connector-for-Informatica/index.html
+  - name: Connector for Tanzu Greenplum<span class='tmr'>&reg;</span> and Tanzu GemFire<span class='tmr'>&reg;</span>
+    url: https://docs.vmware.com/en/Connector-for-VMware-Tanzu-Greenplum-and-VMware-Tanzu-GemFire/index.html
   - name: Tanzu Greenplum<span class='tmr'>&reg; Streaming Server</span>
     url: https://greenplum.docs.pivotal.io/streaming-server
   - name: Greenplum Database


### PR DESCRIPTION
add an entry for the "connector for vmware tanzu greenplum and vmware tanzu gemfire", and link to the soon-to-be-published docs landing page on docs.vmware.com.