### PR TITLE
Update index.html.erb

### DIFF
--- a/master_middleman/source/index.html.erb
+++ b/master_middleman/source/index.html.erb
@@ -548,7 +548,7 @@ addon:
       url: https://docs.pivotal.io/aws-services/index.html
       logo: icon_awsbroker@2x.png
     - name:  Pivotal Telemetry Collector
-      url: https://docs.pivotal.io/telemetry/index.html
+      url: https://docs.vmware.com/en/Tanzu-Telemetry-for-Ops-Manager/index.html
       logo: telemetry-logo.png
     - name: Tanzu Cloud Service Broker<br>for AWS
       url: https://docs.vmware.com/en/Tanzu-Cloud-Service-Broker-for-AWS/1.1/csb-aws/GUID-index.html


### PR DESCRIPTION
Hi,
My name is Nikola and I am part of the Content Ops team. I am helping out with some migration tasks, and would like to create a pull request to change the Tanzu Telemetry for Ops Manager URL to now point to docs.vwmare.com. 
Tanzu Telemetry for Ops Manager URL on VMware Docs -  https://docs.vmware.com/en/Tanzu-Telemetry-for-Ops-Manager/index.html