### PR TITLE
greenplum pxf docs to link to docs.vwmare.com

### DIFF
--- a/master_middleman/source/index.html.erb
+++ b/master_middleman/source/index.html.erb
@@ -128,7 +128,7 @@ top_services:
   - name: Tanzu Greenplum<span class='tmr'>&reg; Upgrade</span>
     url: https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Upgrade/index.html
   - name: Tanzu Greenplum<span class='tmr'>&reg; Platform Extension Framework</span>
-    url: https://greenplum.docs.pivotal.io/pxf
+    url: https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Platform-Extension-Framework/index.html
   - name: Tanzu Greenplum<span class='tmr'>&reg; Data Copy Utility</span>
     url: https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Data-Copy-Utility/index.html
   - name: Tanzu Greenplum<span class='tmr'>&reg;</span> Connector for Apache NiFi<span class='tmr'>&trade;</span>


### PR DESCRIPTION
migrating greenplum platform extension framework docs to docs.vmware.com.

HOLD TIL MIGRATION IS COMPLETE.