### PR TITLE
remove xref for gp4ks from docs.pivotal.io landing page

### DIFF
--- a/master_middleman/source/index.html.erb
+++ b/master_middleman/source/index.html.erb
@@ -117,8 +117,6 @@ top_services:
   links:
   - name: Tanzu Greenplum<span class='tmr'>&reg;</span>
     url: https://docs.vmware.com/en/VMware-Tanzu-Greenplum/index.html
-  - name: Tanzu Greenplum<span class='tmr'>&reg; for Kubernetes</span>
-    url: https://greenplum-kubernetes.docs.pivotal.io
   - name: Tanzu Greenplum<span class='tmr'>&reg; Text</span>
     url: https://docs.vmware.com/en/VMware-Tanzu-Greenplum-Text/index.html
   - name: Tanzu Greenplum<span class='tmr'>&reg; Command Center</span>


### PR DESCRIPTION
get rid of it